### PR TITLE
add static files collection explicitly, improve coding style due to flake8, improve readability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # compiled python files
 *.py[cod]
- 
+
 # emacs temp files
 *~
 [#]*[#]
@@ -23,3 +23,6 @@ db.sqlite3
 
 # bash script to set environment variables
 env.sh
+
+# static root folder for local deployments
+static_root

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ export DJANGO_PRODUCTION_DOMAIN="xxx"
 export DJANGO_LOG_FILE="xxx"
 
 # static and media files dir in production
-export DJANGO_STATIC_ROOT="xxx"
+export DJANGO_STATIC_ROOT="static_root/"
 export DJANGO_MEDIA_ROOT="xxx"
 
 # User who gets django's email notifications (ADMINS/MANAGERS), see settings.py
@@ -56,7 +56,7 @@ export DJANGO_TICKET_EMAIL_NOTIFICATIONS_FROM="xxx"
 export DJANGO_TICKET_EMAIL_NOTIFICATIONS_TO="xxx"
 ```
 
-Please note that `django-tickets` is **not** packaged as a reusable django app; it's a **complete django project**. So just clone the repository and install the dependencies via pip and the application including user authentication is ready to go. 
+Please note that `django-tickets` is **not** packaged as a reusable django app; it's a **complete django project**. So just clone the repository and install the dependencies via pip and the application including user authentication is ready to go.
 
 ```
 $ git clone https://github.com/suenkler/django-tickets.git

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ export DJANGO_PRODUCTION_DOMAIN="xxx"
 # log file
 export DJANGO_LOG_FILE="xxx"
 
-# static and media files dir in production
+# static and media files directories in production
 export DJANGO_STATIC_ROOT="xxx"
 export DJANGO_MEDIA_ROOT="xxx"
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ $ cd django-tickets
 $ pip install -r requirements.txt
 $ source env.sh
 $ ./manage.py migrate
+$ ./manage.py collectstatic
 $ ./manage.py createsuperuser
 $ ./manage.py runserver
 ```

--- a/main/forms.py
+++ b/main/forms.py
@@ -18,11 +18,12 @@ class TicketCreateForm(forms.ModelForm):
         model = Ticket
         fields = ('title', 'description')
 
-        
+
 class TicketEditForm(forms.ModelForm):
     class Meta:
         model = Ticket
-        fields = ('title', 'owner', 'description', 'status', 'waiting_for', 'assigned_to')
+        fields = ('title', 'owner', 'description',
+                  'status', 'waiting_for', 'assigned_to')
 
 
 class FollowupForm(forms.ModelForm):

--- a/main/models.py
+++ b/main/models.py
@@ -22,8 +22,13 @@ User.__unicode__ = user_unicode
 class Ticket(models.Model):
 
     title = models.CharField('Title', max_length=255)
-    owner = models.ForeignKey(User, related_name='owner', blank=True,
-                              null=True, verbose_name='Owner', )
+
+    owner = models.ForeignKey(User,
+                              related_name='owner',
+                              blank=True,
+                              null=True,
+                              verbose_name='Owner')
+
     description = models.TextField('Description', blank=True, null=True)
 
     STATUS_CHOICES = (
@@ -32,12 +37,17 @@ class Ticket(models.Model):
         ('WAITING', 'WAITING'),
         ('DONE', 'DONE'),
     )
-    status = models.CharField('Status', choices=STATUS_CHOICES, max_length=255,
-                              blank=True, null=True)
+    status = models.CharField('Status',
+                              choices=STATUS_CHOICES,
+                              max_length=255,
+                              blank=True,
+                              null=True)
 
-    waiting_for = models.ForeignKey(User, related_name='waiting_for',
-                                    blank=True, null=True,
-                                    verbose_name='Waiting For', )
+    waiting_for = models.ForeignKey(User,
+                                    related_name='waiting_for',
+                                    blank=True,
+                                    null=True,
+                                    verbose_name='Waiting For')
 
     # set in view when status changed to "DONE"
     closed_date = models.DateTimeField(blank=True, null=True)
@@ -46,7 +56,7 @@ class Ticket(models.Model):
                                     related_name='assigned_to',
                                     blank=True,
                                     null=True,
-                                    verbose_name='Assigned to',)
+                                    verbose_name='Assigned to')
 
     created = models.DateTimeField(auto_now_add=True)
     updated = models.DateTimeField(auto_now=True)
@@ -59,11 +69,11 @@ class FollowUp(models.Model):
     """
     A FollowUp is a comment to a ticket.
     """
-    ticket = models.ForeignKey(Ticket, verbose_name='Ticket',)
+    ticket = models.ForeignKey(Ticket, verbose_name='Ticket')
     date = models.DateTimeField('Date', default=timezone.now)
     title = models.CharField('Title', max_length=200,)
     text = models.TextField('Text', blank=True, null=True,)
-    user = models.ForeignKey(User, blank=True, null=True, verbose_name='User',)
+    user = models.ForeignKey(User, blank=True, null=True, verbose_name='User')
     created = models.DateTimeField(auto_now_add=True)
     modified = models.DateTimeField(auto_now=True)
 
@@ -90,11 +100,19 @@ def attachment_path(instance, filename):
 
 
 class Attachment(models.Model):
-    ticket = models.ForeignKey(Ticket, verbose_name='Ticket',)
-    file = models.FileField('File', upload_to=attachment_path,
-                            max_length=1000,)
-    filename = models.CharField('Filename', max_length=1000,)
-    user = models.ForeignKey(User, blank=True, null=True, verbose_name='User',)
+    ticket = models.ForeignKey(Ticket, verbose_name='Ticket')
+
+    file = models.FileField('File',
+                            upload_to=attachment_path,
+                            max_length=1000)
+
+    filename = models.CharField('Filename', max_length=1000)
+
+    user = models.ForeignKey(User,
+                             blank=True,
+                             null=True,
+                             verbose_name='User')
+
     created = models.DateTimeField(auto_now_add=True)
 
     def get_upload_to(self, field_attname):

--- a/main/models.py
+++ b/main/models.py
@@ -13,14 +13,17 @@ def user_unicode(self):
     """
     return 'last_name, first_name' for User by default
     """
-    return  u'%s, %s' % (self.last_name, self.first_name)
+    return u'%s, %s' % (self.last_name, self.first_name)
+
+
 User.__unicode__ = user_unicode
 
 
 class Ticket(models.Model):
 
     title = models.CharField('Title', max_length=255)
-    owner = models.ForeignKey(User, related_name='owner', blank=True, null=True, verbose_name='Owner', )
+    owner = models.ForeignKey(User, related_name='owner', blank=True,
+                              null=True, verbose_name='Owner', )
     description = models.TextField('Description', blank=True, null=True)
 
     STATUS_CHOICES = (
@@ -29,9 +32,15 @@ class Ticket(models.Model):
         ('WAITING', 'WAITING'),
         ('DONE', 'DONE'),
     )
-    status = models.CharField('Status', choices=STATUS_CHOICES, max_length=255, blank=True, null=True)
-    waiting_for = models.ForeignKey(User, related_name='waiting_for', blank=True, null=True, verbose_name='Waiting For', )
-    closed_date = models.DateTimeField(blank=True, null=True)  # set in view when status changed to "DONE"
+    status = models.CharField('Status', choices=STATUS_CHOICES, max_length=255,
+                              blank=True, null=True)
+
+    waiting_for = models.ForeignKey(User, related_name='waiting_for',
+                                    blank=True, null=True,
+                                    verbose_name='Waiting For', )
+
+    # set in view when status changed to "DONE"
+    closed_date = models.DateTimeField(blank=True, null=True)
 
     assigned_to = models.ForeignKey(User,
                                     related_name='assigned_to',
@@ -50,11 +59,11 @@ class FollowUp(models.Model):
     """
     A FollowUp is a comment to a ticket.
     """
-    ticket = models.ForeignKey(Ticket, verbose_name='Ticket', )
+    ticket = models.ForeignKey(Ticket, verbose_name='Ticket',)
     date = models.DateTimeField('Date', default=timezone.now)
-    title = models.CharField('Title', max_length=200, )
-    text = models.TextField('Text', blank=True, null=True, )
-    user = models.ForeignKey(User, blank=True, null=True, verbose_name='User', )
+    title = models.CharField('Title', max_length=200,)
+    text = models.TextField('Text', blank=True, null=True,)
+    user = models.ForeignKey(User, blank=True, null=True, verbose_name='User',)
     created = models.DateTimeField(auto_now_add=True)
     modified = models.DateTimeField(auto_now=True)
 
@@ -73,17 +82,19 @@ def attachment_path(instance, filename):
     path = 'tickets/%s' % instance.ticket.id
     print(path)
     att_path = os.path.join(settings.MEDIA_ROOT, path)
-    if settings.DEFAULT_FILE_STORAGE == "django.core.files.storage.FileSystemStorage":
+    if settings.DEFAULT_FILE_STORAGE == "django.core.files. \
+                                         storage.FileSystemStorage":
         if not os.path.exists(att_path):
             os.makedirs(att_path, 0777)
     return os.path.join(path, filename)
 
 
 class Attachment(models.Model):
-    ticket = models.ForeignKey(Ticket, verbose_name='Ticket', )
-    file = models.FileField('File', upload_to=attachment_path, max_length=1000, )
-    filename = models.CharField('Filename', max_length=1000, )
-    user = models.ForeignKey(User, blank=True, null=True, verbose_name='User', )
+    ticket = models.ForeignKey(Ticket, verbose_name='Ticket',)
+    file = models.FileField('File', upload_to=attachment_path,
+                            max_length=1000,)
+    filename = models.CharField('Filename', max_length=1000,)
+    user = models.ForeignKey(User, blank=True, null=True, verbose_name='User',)
     created = models.DateTimeField(auto_now_add=True)
 
     def get_upload_to(self, field_attname):
@@ -95,6 +106,6 @@ class Attachment(models.Model):
         )
 
     class Meta:
-        #ordering = ['filename', ]
+        # ordering = ['filename', ]
         verbose_name = 'Attachment'
         verbose_name_plural = 'Attachments'

--- a/main/views.py
+++ b/main/views.py
@@ -9,7 +9,8 @@ from django.core.mail import send_mail
 
 from .models import Ticket, Attachment, FollowUp
 from .forms import UserSettingsForm
-from .forms import TicketCreateForm, TicketEditForm, FollowupForm, AttachmentForm
+from .forms import TicketCreateForm, TicketEditForm, \
+                   FollowupForm, AttachmentForm
 
 # Logging
 import logging
@@ -30,13 +31,14 @@ def inbox_view(request):
 
 def my_tickets_view(request):
 
-    tickets = Ticket.objects.filter(assigned_to=request.user).exclude(status__exact="DONE")
-    tickets_waiting = Ticket.objects.filter(waiting_for=request.user).filter(status__exact="WAITING")
+    tickets = Ticket.objects.filter(assigned_to=request.user) \
+                    .exclude(status__exact="DONE")
+    tickets_waiting = Ticket.objects.filter(waiting_for=request.user) \
+                                    .filter(status__exact="WAITING")
 
-    
     return render_to_response('main/my-tickets.html',
                               {"tickets": tickets,
-                               "tickets_waiting": tickets_waiting },
+                               "tickets_waiting": tickets_waiting},
                               context_instance=RequestContext(request))
 
 
@@ -81,7 +83,7 @@ def usersettings_update_view(request):
     else:
         form_user = UserSettingsForm(instance=user)
 
-    return render(request, 'main/settings.html', {'form_user': form_user,})
+    return render(request, 'main/settings.html', {'form_user': form_user, })
 
 
 def ticket_create_view(request):
@@ -156,15 +158,15 @@ def followup_create_view(request):
             ticket = Ticket.objects.get(id=request.POST['ticket'])
             # mail notification to owner of ticket
             notification_subject = "[#" + str(ticket.id) + "] New followup"
-            notification_body = "Hi,\n\na new followup was created for ticket #" \
+            notification_body = "Hi,\n\n new followup created for ticket #" \
                                 + str(ticket.id) \
                                 + " (http://localhost:8000/ticket/" \
                                 + str(ticket.id) \
                                 + "/)\n\nTitle: " + form.data['title'] \
                                 + "\n\n" + form.data['text']
 
-            send_mail(notification_subject, notification_body, 'test@suenkler.info',
-                            [ticket.owner.email], fail_silently=False)
+            send_mail(notification_subject, notification_body, 'test@test.tld',
+                      [ticket.owner.email], fail_silently=False)
 
             return redirect('inbox')
 
@@ -207,8 +209,8 @@ def attachment_create_view(request):
                 file=request.FILES['file'],
                 filename=request.FILES['file'].name,
                 user=request.user
-                #mime_type=form.file.get_content_type(),
-                #size=len(form.file),
+                # mime_type=form.file.get_content_type(),
+                # size=len(form.file),
             )
             attachment.save()
 

--- a/tickets/settings.py
+++ b/tickets/settings.py
@@ -3,6 +3,8 @@
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
 import socket
+# request.path in templates:
+from django.conf.global_settings import TEMPLATE_CONTEXT_PROCESSORS as TCP
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
@@ -32,8 +34,6 @@ INSTALLED_APPS = (
     'main',
 )
 
-# request.path in templates:
-from django.conf.global_settings import TEMPLATE_CONTEXT_PROCESSORS as TCP
 TEMPLATE_CONTEXT_PROCESSORS = TCP + (
     'django.core.context_processors.request',
 )
@@ -96,11 +96,13 @@ CRISPY_TEMPLATE_PACK = 'bootstrap3'
 # Define who gets code error notifications.
 # When DEBUG=False and a view raises an exception,
 # Django will email these people with the full exception information.
-ADMINS = ((os.environ["DJANGO_ADMIN_NAME"], os.environ["DJANGO_ADMIN_EMAIL"]), )
+ADMINS = ((os.environ["DJANGO_ADMIN_NAME"],
+           os.environ["DJANGO_ADMIN_EMAIL"]), )
 
 # Specifies who should get broken link notifications when
 # BrokenLinkEmailsMiddleware is enabled.
-MANAGERS = ((os.environ["DJANGO_ADMIN_NAME"], os.environ["DJANGO_ADMIN_EMAIL"]), )
+MANAGERS = ((os.environ["DJANGO_ADMIN_NAME"],
+             os.environ["DJANGO_ADMIN_EMAIL"]), )
 
 # Email delivery to local Postfix-Installation
 EMAIL_HOST = os.environ["DJANGO_EMAIL_HOST"]
@@ -113,7 +115,8 @@ LOGGING = {
     'disable_existing_loggers': False,
     'formatters': {
         'verbose': {
-            'format': "[%(asctime)s] %(levelname)s [%(name)s:%(lineno)s] %(message)s",
+            'format': "[%(asctime)s] %(levelname)s \
+                       [%(name)s:%(lineno)s] %(message)s",
             'datefmt': "%d/%b/%Y %H:%M:%S"
         },
         'simple': {

--- a/tickets/urls.py
+++ b/tickets/urls.py
@@ -10,37 +10,66 @@ from django.contrib.auth.decorators import login_required
 from django.conf import settings
 from django.conf.urls.static import static
 
-urlpatterns = patterns('',
+urlpatterns = patterns(
+    '',
 
     # Login and settings pages
     url(r'^$', 'django.contrib.auth.views.login'),
+
     url(r'^logout/$', 'django.contrib.auth.views.logout_then_login'),
-    url(r'^settings/$', login_required(main.views.usersettings_update_view), name='user-settings'),
+
+    url(r'^settings/$',
+        login_required(main.views.usersettings_update_view),
+        name='user-settings'),
 
     # Django admin
     url(r'^admin/', include(admin.site.urls)),
 
     # create new ticket
-    url(r'^ticket/new/$', login_required(main.views.ticket_create_view), name='ticket_new'),
+    url(r'^ticket/new/$',
+        login_required(main.views.ticket_create_view),
+        name='ticket_new'),
 
     # edit ticket
-    url(r'^ticket/edit/(?P<pk>\d+)/$', login_required(main.views.ticket_edit_view), name='ticket_edit'),
+    url(r'^ticket/edit/(?P<pk>\d+)/$',
+        login_required(main.views.ticket_edit_view),
+        name='ticket_edit'),
 
     # view ticket
-    url(r'^ticket/(?P<pk>\d+)/$', login_required(main.views.ticket_detail_view), name='ticket_detail'),
+    url(r'^ticket/(?P<pk>\d+)/$',
+        login_required(main.views.ticket_detail_view),
+        name='ticket_detail'),
 
     # create new followup
-    url(r'^followup/new/$', login_required(main.views.followup_create_view), name='followup_new'),
+    url(r'^followup/new/$',
+        login_required(main.views.followup_create_view),
+        name='followup_new'),
 
     # edit followup
-    url(r'^followup/edit/(?P<pk>\d+)/$', login_required(main.views.followup_edit_view), name='followup_edit'),
+    url(r'^followup/edit/(?P<pk>\d+)/$',
+        login_required(main.views.followup_edit_view),
+        name='followup_edit'),
 
     # create new attachment
-    url(r'^attachment/new/$', login_required(main.views.attachment_create_view), name='attachment_new'),
+    url(r'^attachment/new/$',
+        login_required(main.views.attachment_create_view),
+        name='attachment_new'),
 
     # ticket overviews
-    url(r'^inbox/$', login_required(main.views.inbox_view), name='inbox'),
-    url(r'^my-tickets/$', login_required(main.views.my_tickets_view), name='my-tickets'),
-    url(r'^all-tickets/$', login_required(main.views.all_tickets_view), name='all-tickets'),
-    url(r'^archive/$', login_required(main.views.archive_view), name='archive'),
+    url(r'^inbox/$',
+        login_required(main.views.inbox_view),
+        name='inbox'),
+
+    url(r'^my-tickets/$',
+        login_required(main.views.my_tickets_view),
+        name='my-tickets'),
+
+    url(r'^all-tickets/$',
+        login_required(main.views.all_tickets_view),
+        name='all-tickets'),
+
+    url(r'^archive/$',
+        login_required(main.views.archive_view),
+        name='archive'),
+
 ) + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
Since static files [usually get collected](http://stackoverflow.com/questions/8687927/django-static-static-url-static-root) I added this step to the quickstart instructions for local deployment.

The coding style was improved due to [flake8 recommendations](https://pypi.python.org/pypi/flake8) and turns out to approximate quadratic shape.

There should not be any change in functionality so far.